### PR TITLE
Fix a bug where ctrl+1/2/3/4 cause the reader to switch between translators

### DIFF
--- a/web/src/pages/reader/Reader.vue
+++ b/web/src/pages/reader/Reader.vue
@@ -148,6 +148,9 @@ onKeyDown(['ArrowRight'], (e) => {
 });
 
 onKeyDown(['1', '2', '3', '4'], (e) => {
+  if (e.altKey || e.ctrlKey || e.shiftKey || e.metaKey) {
+    return;
+  }
   const setting = Locator.readerSettingRepository().setting.value;
 
   const translatorIds = <TranslatorId[]>['baidu', 'youdao', 'gpt', 'sakura'];


### PR DESCRIPTION
如题，这个 PR 修复了 Ctrl/Shift/Meta/Alt + 1/2/3/4 在阅读界面会切换翻译，导致与浏览器快捷键冲突的问题。

现在的行为也和其他快捷键一致。