### PR TITLE
fix(web): 删除一级评论后刷新评论列表

### DIFF
--- a/web/src/components/comment/CommentList.vue
+++ b/web/src/components/comment/CommentList.vue
@@ -100,7 +100,12 @@ const showInput = ref(false);
     v-slot="{ value }"
   >
     <template v-for="comment in value.items">
-      <CommentThread :site="site" :comment="comment" :locked="locked" />
+      <CommentThread
+        :site="site"
+        :comment="comment"
+        :locked="locked"
+        @deleted="loadComments(currentPage)"
+      />
       <n-divider />
     </template>
 

--- a/web/src/components/comment/CommentThread.vue
+++ b/web/src/components/comment/CommentThread.vue
@@ -19,6 +19,10 @@ const pageCount = ref(Math.floor((comment.numReplies + 9) / 10));
 const draftRepo = Locator.draftRepository();
 const draftId = `comment-${site}`;
 
+const emit = defineEmits<{
+  deleted: [];
+}>();
+
 const loadReplies = async (page: number) => {
   const result = await runCatching(
     CommentRepository.listComment({
@@ -53,10 +57,14 @@ const copyComment = (comment: Comment1) =>
     else message.error('复制失败');
   });
 
-const deleteComment = (comment: Comment1) =>
+const deleteComment = (commentToDelete: Comment1) =>
   doAction(
-    CommentRepository.deleteComment(comment.id).then(() => {
-      loadReplies(currentPage.value);
+    CommentRepository.deleteComment(commentToDelete.id).then(() => {
+      if (commentToDelete.id === comment.id) {
+        emit('deleted');
+      } else {
+        loadReplies(currentPage.value);
+      }
     }),
     '删除',
     message,


### PR DESCRIPTION
## Problem

原本在 [web\src\components\comment\CommentThread.vue](web\src\components\comment\CommentThread.vue) 中，删除评论后会调用 `loadReplies` 刷新当前楼中楼。因此，删除一级评论后，在不刷新页面的情况下，看不到评论列表的变化。

## Fix

通过 emit 事件通知父组件 [CommentList.vue](web\src\components\comment\CommentList.vue)，在删除一级评论后调用 `loadComments` 刷新评论列表。

> 删除次级评论时的行为无变化（不会同时执行 `loadReplies` 和 `loadComments`）。